### PR TITLE
Load .ply files for avatars

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -6,3 +6,5 @@
 6. Functionality to load more than .ply if it is in the same folder
 7. ✅ Add background color as a setting per scene (in the .jsons)
 8. ✅ Remove the "Background" setting and functionality
+9. Explore if we can reduce the time used in re-indexing the gaussians array 
+10. Migrate the repo to IGZ's org

--- a/src/loader.js
+++ b/src/loader.js
@@ -8,30 +8,31 @@ async function loadPly(content) {
     const [ header ] = contentStart.split('end_header')
 
     // Get number of gaussians
-    const regex = /element vertex (\d+)/
-    const match = header.match(regex)
+    const match = header.match(/element vertex (\d+)/)
+    const gaussianCount = parseInt(match[1])
+
+    // Check if the .ply is an IGZ avatar
+    const match_avatar = header.match(/igz_avatar/)
+    let isAvatar;
+    if (match_avatar != null) {
+        isAvatar = true
+    }
+    else {
+        isAvatar = false
+    }
 
     // Get number of SH coefficients (the model may have been trained with a lower SH degree)
-    const regex_sh = /f_rest_(\d+)/g
-    const match_sh = header.match(regex_sh)
+    const match_sh = header.match(/f_rest_(\d+)/g)
     if (match_sh == null) {
         n_sh = 3
     }
     else {
         n_sh = 3 + match_sh.length
     }
-    gaussianCount = parseInt(match[1])
 
     // document.querySelector('#loading-text').textContent = `Success. Initializing ${gaussianCount} gaussians...`
+    console.log(`.ply file found, initializing ${gaussianCount.toLocaleString()} gaussians...`);
 
-    // Create arrays for gaussian properties
-    const positions = []
-    const opacities = []
-    const rotations = []
-    const scales = []
-    const harmonics = []
-    const colors = []
-    const cov3Ds = []
 
     // Scene bouding box
     sceneMin = new Array(3).fill(Infinity)
@@ -42,11 +43,15 @@ async function loadPly(content) {
     
     // Helpers
     const sigmoid = (m1) => 1 / (1 + Math.exp(-m1))
-    const NUM_PROPS = 14 + n_sh // If the gaussian has been trained with a lower SH degree, this number will be lower
-
+    if (isAvatar) {
+        NUM_PROPS = 7
+    }
+    else {
+        NUM_PROPS = 14 + n_sh // If the gaussian has been trained with a lower SH degree, this number will be lower
+    }
     // Get a slice of the dataview relative to a splat index
     const fromDataView = (splatID, start, end) => {
-        const startOffset = headerEnd + splatID * NUM_PROPS * 4 + start * 4
+        const startOffset = headerEnd + splatID * NUM_PROPS * 4 + start * 4 // by 4 because each float is 4 bytes
 
         if (end == null) 
             return view.getFloat32(startOffset, true)
@@ -80,42 +85,111 @@ async function loadPly(content) {
         return { position, harmonic, opacity, scale, rotation }
     }
 
-    for (let i = 0; i < gaussianCount; i++) {
-        // Extract data for current gaussian
-        let { position, harmonic, opacity, scale, rotation } = extractSplatData(i)
+    const extractSplatDataIsAvatar = (splatID) => {
+        const position = fromDataView(splatID, 0, 3)        
+        const harmonic_raw = fromDataView(splatID, 3, 6)
         
-        // Update scene bounding box
-        sceneMin = sceneMin.map((v, j) => Math.min(v, position[j]))
-        sceneMax = sceneMax.map((v, j) => Math.max(v, position[j]))
+        // Need to re-order harmonic_raw[3:] (see the original paper's python implementation of GaussianModel.load_ply)
+        const harmonic = [harmonic_raw[0], harmonic_raw[1], harmonic_raw[2]]
+        const scale = fromDataView(splatID, 6, 7)
+    
+        return { position, harmonic, scale}
+    }
 
-        // Normalize quaternion
-        let length2 = 0
+    const extractDataAllSplats = (gaussianCount) => {
+    
+        // Create arrays for gaussian properties
+        const positions = []
+        const opacities = []
+        const scales = []
+        const harmonics = []
+        const colors = []
+        const cov3Ds = []
+    
+        for (let i = 0; i < gaussianCount; i++) {
+            // Extract data for current gaussian
+            let { position, harmonic, opacity, scale, rotation } = extractSplatData(i)
+            
+            // Update scene bounding box
+            sceneMin = sceneMin.map((v, j) => Math.min(v, position[j]))
+            sceneMax = sceneMax.map((v, j) => Math.max(v, position[j]))
 
-        for (let j = 0; j < 4; j++)
-            length2 += rotation[j] * rotation[j]
+            // Normalize quaternion
+            let length2 = 0
 
-        const length = Math.sqrt(length2)
+            for (let j = 0; j < 4; j++)
+                length2 += rotation[j] * rotation[j]
 
-        rotation = rotation.map(v => v / length)  
+            const length = Math.sqrt(length2)
 
-        // Exponentiate scale
-        scale = scale.map(v => Math.exp(v))
+            rotation = rotation.map(v => v / length)  
 
-        // Activate alpha
-        opacity = sigmoid(opacity)
-        opacities.push(opacity)
+            // Exponentiate scale
+            scale = scale.map(v => Math.exp(v))
 
-        // (Webgl-specific) Equivalent to computeColorFromSH() with degree 0:
-        // Use the first spherical harmonic to pre-compute the color.
-        // This allow to avoid sending harmonics to the web worker or GPU,
-        // but removes view-dependent lighting effects like reflections.
-        // If we were to use a degree > 0, we would need to recompute the color 
-        // each time the camera moves, and send many more harmonics to the worker:
-        // Degree 1: 4 harmonics needed (12 floats) per gaussian
-        // Degree 2: 9 harmonics needed (27 floats) per gaussian
-        // Degree 3: 16 harmonics needed (48 floats) per gaussian
+            // Activate alpha
+            opacity = sigmoid(opacity)
+            opacities.push(opacity)
+
+            // (Webgl-specific) Equivalent to computeColorFromSH() with degree 0:
+            // Use the first spherical harmonic to pre-compute the color.
+            // This allow to avoid sending harmonics to the web worker or GPU,
+            // but removes view-dependent lighting effects like reflections.
+            // If we were to use a degree > 0, we would need to recompute the color 
+            // each time the camera moves, and send many more harmonics to the worker:
+            // Degree 1: 4 harmonics needed (12 floats) per gaussian
+            // Degree 2: 9 harmonics needed (27 floats) per gaussian
+            // Degree 3: 16 harmonics needed (48 floats) per gaussian
+            
+            if (n_sh == 3) {
+                const SH_C0 = 0.28209479177387814
+                const color = [
+                    0.5 + SH_C0 * harmonic[0],
+                    0.5 + SH_C0 * harmonic[1],
+                    0.5 + SH_C0 * harmonic[2]
+                ]
+                colors.push(...color)
+            }
+            else {
+                harmonics.push(...harmonic) 
+            }
+
+            // (Webgl-specific) Pre-compute the 3D covariance matrix from
+            // the rotation and scale in order to avoid recomputing it at each frame.
+            // This also allow to avoid sending rotations and scales to the web worker or GPU.
+            const cov3D = computeCov3D(scale, 1, rotation)
+            cov3Ds.push(...cov3D)
+            // rotations.push(...rotation)
+            scales.push(...scale)
+
+            positions.push(...position)
+        }
         
-        if (n_sh == 3) {
+        return {positions, opacities, colors, cov3Ds, scales, harmonics}
+    }
+
+    const extractDataAllSplatsAvatar = (gaussianCount) => {
+    
+        // Create arrays for gaussian properties
+        const positions = []
+        const scales = []
+        const colors = []
+    
+        for (let i = 0; i < gaussianCount; i++) {
+            // Extract data for current gaussian
+            let { position, harmonic, scale} = extractSplatDataIsAvatar(i)
+            
+            // Update scene bounding box
+            sceneMin = sceneMin.map((v, j) => Math.min(v, position[j]))
+            sceneMax = sceneMax.map((v, j) => Math.max(v, position[j]))
+
+            positions.push(...position)
+
+            // Exponentiate scale
+            scale = scale.map(v => Math.exp(v))
+            scales.push(...scale)
+
+
             const SH_C0 = 0.28209479177387814
             const color = [
                 0.5 + SH_C0 * harmonic[0],
@@ -123,25 +197,29 @@ async function loadPly(content) {
                 0.5 + SH_C0 * harmonic[2]
             ]
             colors.push(...color)
-        }
-        else {
-            harmonics.push(...harmonic) 
-        }
 
-        // (Webgl-specific) Pre-compute the 3D covariance matrix from
-        // the rotation and scale in order to avoid recomputing it at each frame.
-        // This also allow to avoid sending rotations and scales to the web worker or GPU.
-        const cov3D = computeCov3D(scale, 1, rotation)
-        cov3Ds.push(...cov3D)
-        // rotations.push(...rotation)
-        scales.push(...scale)
-
-        positions.push(...position)
+            // (Webgl-specific) Pre-compute the 3D covariance matrix from
+            // the rotation and scale in order to avoid recomputing it at each frame.
+            // This also allow to avoid sending rotations and scales to the web worker or GPU.
+            // const cov3D = computeCov3D(scale, 1, rotation)
+            // cov3Ds.push(...cov3D)
+            // rotations.push(...rotation)
+        }
+        
+        return {positions, colors, scales}
     }
+  
 
-    // console.log(`Loaded ${gaussianCount} gaussians in ${((performance.now() - start)/1000).toFixed(3)}s`)
-    
-    return { positions, opacities, colors, cov3Ds, scales, harmonics}
+    if (isAvatar) {        
+        splatsData = extractDataAllSplatsAvatar(gaussianCount)
+        console.log(`Loaded ${gaussianCount} gaussians in ${((performance.now() - start)/1000).toFixed(3)}s`)
+        return splatsData     
+    }
+    else {
+        splatsData = extractDataAllSplats(gaussianCount)
+        console.log(`Loaded ${gaussianCount} gaussians in ${((performance.now() - start)/1000).toFixed(3)}s`)
+        return splatsData
+    }
 }
 
 

--- a/src/loader.js
+++ b/src/loader.js
@@ -31,7 +31,7 @@ async function loadPly(content) {
     }
 
     // document.querySelector('#loading-text').textContent = `Success. Initializing ${gaussianCount} gaussians...`
-    console.log(`.ply file found, initializing ${gaussianCount.toLocaleString()} gaussians...`);
+    // console.log(`.ply file found, initializing ${gaussianCount.toLocaleString()} gaussians...`);
 
 
     // Scene bouding box
@@ -153,7 +153,6 @@ async function loadPly(content) {
             else {
                 harmonics.push(...harmonic) 
             }
-
             // (Webgl-specific) Pre-compute the 3D covariance matrix from
             // the rotation and scale in order to avoid recomputing it at each frame.
             // This also allow to avoid sending rotations and scales to the web worker or GPU.
@@ -212,12 +211,12 @@ async function loadPly(content) {
 
     if (isAvatar) {        
         splatsData = extractDataAllSplatsAvatar(gaussianCount)
-        console.log(`Loaded ${gaussianCount} gaussians in ${((performance.now() - start)/1000).toFixed(3)}s`)
+        // console.log(`Loaded ${gaussianCount} gaussians in ${((performance.now() - start)/1000).toFixed(3)}s`)
         return splatsData     
     }
     else {
         splatsData = extractDataAllSplats(gaussianCount)
-        console.log(`Loaded ${gaussianCount} gaussians in ${((performance.now() - start)/1000).toFixed(3)}s`)
+        // console.log(`Loaded ${gaussianCount} gaussians in ${((performance.now() - start)/1000).toFixed(3)}s`)
         return splatsData
     }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -179,19 +179,20 @@ async function loadFramesPly(frames_folder) {
             contentLength.push(parseInt(response.headers.get('content-length')))
             reader.push(response.body.getReader())
             i++
-            console.log("Frame", i, "loaded")
         }
         else {
             break
         }
     }
-
+    let n_frames = reader.length    
     for (let i = 0; i < reader.length; i++) {
         // Download .ply file and monitor the progress
+        let start = performance.now()
         const content = await downloadPly(reader[i], contentLength[i])
         // Load and pre-process gaussian data from .ply file
-        frame_ply_data = await loadPly(content.buffer)
+        frame_ply_data = await loadPly(content.buffer)        
         data.push(frame_ply_data)
+        console.log(`Frame ${i}/${n_frames} loaded in ${((performance.now() - start)/1000).toFixed(3)}s`)
         // const progress = ((i + 1) /n_frames) * 100
         // document.querySelector('#loading-bar').style.width = progress + '%'
         // document.querySelector('#loading-text').textContent = `Downloading 3D frames (${(i + 1)}/${n_frames}) ... ${progress.toFixed(2)}%`
@@ -224,7 +225,7 @@ async function loadStaticScene(scene_name, background_data, backgroundColorHEX) 
 
     // Print gravity center
     getGravityCenter(data)
-    delete data.scales
+    // delete data.scales
 
     // Send gaussian data to the worker
     // console.log(`Sending static gaussian data to worker`)

--- a/src/main.js
+++ b/src/main.js
@@ -115,10 +115,6 @@ async function loadScene(scene_name, back_name) {
 
     cam = new Camera(defaultCameraParameters)
     cam.disableMovement = true
-    var back_data = null
-    if (back_name != 'None') {
-        var back_data = await loadBackgroundPly(back_name)
-    }
     // if (scene_name.includes('dynamic')) {
     if (defaultCameraParameters.isDynamic) {
       console.log("Loading Dynamic Scene");
@@ -126,48 +122,36 @@ async function loadScene(scene_name, back_name) {
       const frames_data = await loadFramesPly(scene_name);
       // Load the first frame
       window.frame_idx = 0;
-      loadNextFrame(frames_data, back_data, CameraParameters.backgroundColorHEX);
+      loadNextFrame(frames_data, CameraParameters.backgroundColorHEX);
       // Wait 3 seconds for the first frame to be loaded before starting the interval
       await sleep(3000);
-      stopInterval = setInterval(() => loadNextFrame(frames_data, back_data, CameraParameters.backgroundColorHEX), 500);
-      //await load_next_frame(frames_data, back_data)
+      stopInterval = setInterval(() => loadNextFrame(frames_data, CameraParameters.backgroundColorHEX), 500);
     } else {
         // Load the a static scene
         console.log("Loading Static Scene");
-        await loadStaticScene(scene_name, back_data, CameraParameters.backgroundColorHEX);
+        await loadStaticScene(scene_name, CameraParameters.backgroundColorHEX);
     }
     cam.disableMovement = false
     document.body.style.backgroundColor = defaultCameraParameters.backgroundColorHEX;
 
 }
 
-async function sendGaussianDataToWorker(scene_data, background_data) {
+async function sendGaussianDataToWorker(scene_data) {
 
     var data_to_send = scene_data
     gaussianCount = scene_data.positions.length / 3
-    if (background_data) {
-        start = performance.now()
-        gaussianCount += background_data.positions.length / 3
-
-        data_to_send.positions = data_to_send.positions.concat(background_data.positions)
-        data_to_send.colors = data_to_send.colors.concat(background_data.colors)
-        data_to_send.opacities = data_to_send.opacities.concat(background_data.opacities)
-        data_to_send.cov3Ds = data_to_send.cov3Ds.concat(background_data.cov3Ds)
-        const appendTime = `${((performance.now() - start)/1000).toFixed(3)}s`
-        // console.log(`[Frame loader] Appended background data in ${appendTime}`)
-    }
     settings.maxGaussians = gaussianCount
     worker.postMessage({gaussians: { ...data_to_send, count: gaussianCount }})
 
 }
 
 
-async function loadNextFrame(frames_data, background_data, backgroundColorHEX) {
+async function loadNextFrame(frames_data, backgroundColorHEX) {
 
     // Send gaussian data to the worker
     gaussianCount = frames_data[window.frame_idx].positions.length / 3
     // console.log(`Sending frame ${window.frame_idx} to worker`)
-    await sendGaussianDataToWorker(frames_data[window.frame_idx], background_data)
+    await sendGaussianDataToWorker(frames_data[window.frame_idx])
     // Append the back data to the data elements if it exists
     cam.update(is_dynamic=true)
     document.getElementById('frameNumber').innerText = `Frame: ${window.frame_idx}`;
@@ -211,23 +195,11 @@ async function loadFramesPly(frames_folder) {
         // const progress = ((i + 1) /n_frames) * 100
         // document.querySelector('#loading-bar').style.width = progress + '%'
         // document.querySelector('#loading-text').textContent = `Downloading 3D frames (${(i + 1)}/${n_frames}) ... ${progress.toFixed(2)}%`
-        console.log("Processing Frame", i, "/", n_frames);
     }
     return data
 }
 
-async function loadBackgroundPly(back_name) {
-    showLoading()
-    response = await fetch(`models/${back_name}.ply`)
-    contentLength = parseInt(response.headers.get('content-length'))
-    reader = response.body.getReader()
-    background_data = []
-    const content = await downloadPly(reader, contentLength)
-    back_data = await loadPly(content.buffer)
-    // getGravityCenter(back_data)
-    delete back_data.scales
-    return back_data
-}
+
 
 // Load a .ply scene specified as a name (URL fetch) or local file
 async function loadStaticScene(scene_name, background_data, backgroundColorHEX) {
@@ -256,7 +228,7 @@ async function loadStaticScene(scene_name, background_data, backgroundColorHEX) 
 
     // Send gaussian data to the worker
     // console.log(`Sending static gaussian data to worker`)
-    await sendGaussianDataToWorker(data, background_data)
+    await sendGaussianDataToWorker(data)
     document.body.style.backgroundColor = backgroundColorHEX;
     cam.update(is_dynamic=false)
 

--- a/src/main.js
+++ b/src/main.js
@@ -199,14 +199,12 @@ async function loadFramesPly(frames_folder) {
             break
         }
     }
-    const n_frames = i
 
     for (let i = 0; i < reader.length; i++) {
         // Download .ply file and monitor the progress
         const content = await downloadPly(reader[i], contentLength[i])
         // Load and pre-process gaussian data from .ply file
         frame_ply_data = await loadPly(content.buffer)
-        delete frame_ply_data.scales
         data.push(frame_ply_data)
         // const progress = ((i + 1) /n_frames) * 100
         // document.querySelector('#loading-bar').style.width = progress + '%'

--- a/src/worker-sort.js
+++ b/src/worker-sort.js
@@ -72,7 +72,7 @@ onmessage = function(event) {
                 scale = gaussians.scales[i]
                 // This is the upper triangle of teh Cov matrix when the scale is constant
                 // and the rotation is the identity
-                cov3Ds = new Float32Array([scale**2, 0, 0, 0, scale**2, 0, 0, 0, scale**2])
+                cov3Ds = new Float32Array([scale**2, 0, 0, scale**2, 0, scale**2])
             }
             else {
                 data.opacities[j] = gaussians.opacities[i]


### PR DESCRIPTION
Changes:

* Added functionality to load .plys that have been created as Gaussian Avatars. Those .plys contain 1/3 of the data of the original .ply files because of the underlying assumptions (e.g. the gaussians always have identity rotation)
* Added functionality to render gaussian clouds created as Gaussian Avatars
* Minor changes to the logging
* Removed unnecessary code related to the background .ply functionality that we have removed